### PR TITLE
Visibitlity fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.bah</groupId>
   <artifactId>geterdun</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>Get'r Done</name>
   <description>A simple framework for getting idempotent actions done, in a reliable way.</description>
   <url>http://github.com/booz-allen-hamilton/geterdun</url>

--- a/src/main/java/com/bah/geterdun/LogResolver.java
+++ b/src/main/java/com/bah/geterdun/LogResolver.java
@@ -12,7 +12,7 @@ import org.apache.hadoop.io.Writable;
  * 
  * @param <EVENT>
  */
-class LogResolver<EVENT> {
+public class LogResolver<EVENT> {
 
   public static class CorruptLogException extends Exception {
 

--- a/src/main/java/com/bah/geterdun/LogResolver.java
+++ b/src/main/java/com/bah/geterdun/LogResolver.java
@@ -21,9 +21,9 @@ class LogResolver<EVENT> {
     private long length;
     private String location;
 
-    public CorruptLogException(long position, long length, String location) {
+    CorruptLogException(long position, long length, String location, Exception source) {
       super("Corrupt log " + location + " discovered at " + position + " of "
-          + length);
+          + length, source);
       this.position = position;
       this.length = length;
       this.location = location;
@@ -74,7 +74,7 @@ class LogResolver<EVENT> {
           eventMap.remove(commitId);
         }
       } catch (IOException e) {
-        throw new CorruptLogException(stream.getPos(), streamLength, location);
+        throw new CorruptLogException(stream.getPos(), streamLength, location, e);
       }
     }
   }


### PR DESCRIPTION
Fixed LogResolver class visibility

LogResolver class has to be public so CorruptLogException could be
referenced from custom CorruptionHandler implementation.